### PR TITLE
Handle local_symbol quotes from RabbitMQ

### DIFF
--- a/rabbitmq_webapp/publisher.py
+++ b/rabbitmq_webapp/publisher.py
@@ -3,10 +3,12 @@ import time
 import pika
 
 messages = [
-    {"symbol": "EURUSD-X", "bid": 1.16683, "ask": 1.16698, "time": "16:43:49"},
-    {"symbol": "USDRY-X", "bid": 41.13920, "ask": 41.16120, "time": "16:43:35"},
-    {"symbol": "XAUUSD-X", "bid": 3505.820, "ask": 3506.250, "time": "16:43:50"},
-    {"symbol": "XAUUSDM25-X", "bid": 3570.160, "ask": 3570.350, "time": "16:43:50"},
+    {
+        "local_symbol": "GCZ5",
+        "bidprice": 3573.7,
+        "askprice": 3573.8,
+        "time": "2025-09-02T15:12:33.1428118Z",
+    }
 ]
 
 connection = pika.BlockingConnection(pika.ConnectionParameters())


### PR DESCRIPTION
## Summary
- support RabbitMQ messages that use local_symbol, bidprice, and askprice keys
- update sample publisher message to demonstrate new format

## Testing
- `python -m py_compile rabbitmq_webapp/app.py rabbitmq_webapp/publisher.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7099bd63c832bbc7d9eb5259451fc