### PR TITLE
Add spread column to quotes table

### DIFF
--- a/zeromq_webapp/templates/index.html
+++ b/zeromq_webapp/templates/index.html
@@ -12,6 +12,7 @@
           <th>Local Symbol</th>
           <th>Bid Price</th>
           <th>Ask Price</th>
+          <th>Spread</th>
           <th>Time</th>
         </tr>
       </thead>
@@ -66,11 +67,12 @@
               diffChart.update();
             }
             rows.forEach(row => {
+              row.spread = (parseFloat(row.askprice) - parseFloat(row.bidprice)).toFixed(2);
               const tr = document.createElement('tr');
-              ['local_symbol','bidprice','askprice','time'].forEach(col => {
+              ['local_symbol','bidprice','askprice','spread','time'].forEach(col => {
                 const td = document.createElement('td');
                 td.textContent = row[col];
-                if (col === 'bidprice' || col === 'askprice') {
+                if (col === 'bidprice' || col === 'askprice' || col === 'spread') {
                   td.className = parseFloat(row[col]) >= 0 ? 'green' : 'red';
                 }
                 tr.appendChild(td);


### PR DESCRIPTION
## Summary
- display bid/ask spread for each symbol including synthetic DIFF-Z5-V5 row
- compute spread from ask and bid prices and color positive/negative values

## Testing
- `pip install ibapi`
- `pytest` *(fails: AttributeError: 'Enum' object has no attribute 'toStr')*

------
https://chatgpt.com/codex/tasks/task_e_68b7f337cff0832ba8786f6adc86c14a