### PR TITLE
Add spread calculation to ZmqPublisher

### DIFF
--- a/samples/CSharp/IBSampleApp/util/ZmqPublisher.cs
+++ b/samples/CSharp/IBSampleApp/util/ZmqPublisher.cs
@@ -15,6 +15,11 @@ namespace IBSampleApp.util
             publisher.Bind("tcp://*:5555");
         }
 
+        public static double CalculateSpread(double bidPrice, double askPrice)
+        {
+            return Math.Abs(askPrice - bidPrice);
+        }
+
         public static void Publish(string symbol, double bidPrice, double askPrice, DateTime time)
         {
             var payload = new
@@ -22,6 +27,7 @@ namespace IBSampleApp.util
                 local_symbol = symbol,
                 bidprice = bidPrice,
                 askprice = askPrice,
+                spread = CalculateSpread(bidPrice, askPrice),
                 time = time.ToString("o")
             };
             publisher.SendFrame(JsonConvert.SerializeObject(payload));


### PR DESCRIPTION
## Summary
- add utility method to compute spread between ask and bid prices
- include spread field in ZeroMQ market data publication

## Testing
- `dotnet test tests/TWSLibTestProject/TWSLibTestProject.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f65ee54c832bb90b01a8de07cd77