### PR TITLE
Compute spread from ask and bid prices

### DIFF
--- a/zeromq_webapp/templates/index.html
+++ b/zeromq_webapp/templates/index.html
@@ -67,7 +67,7 @@
               diffChart.update();
             }
             rows.forEach(row => {
-              row.spread = (parseFloat(row.bidprice) - parseFloat(row.askprice)).toFixed(2);
+              row.spread = Math.abs(parseFloat(row.askprice) - parseFloat(row.bidprice)).toFixed(2);
               const tr = document.createElement('tr');
               ['local_symbol','bidprice','askprice','spread','time'].forEach(col => {
                 const td = document.createElement('td');


### PR DESCRIPTION
## Summary
- display market spread as absolute difference between ask and bid prices

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'ibapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b7f902a5a0832bb00bfaacac95db37