### PR TITLE
Configure webapp host and port

### DIFF
--- a/zeromq_webapp/app.py
+++ b/zeromq_webapp/app.py
@@ -60,4 +60,4 @@ def data_endpoint():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(host="172.31.28.98", port=80, debug=True)


### PR DESCRIPTION
## Summary
- serve the Flask webapp on 172.31.28.98:80 so index.html is accessible over the desired address

## Testing
- `python -m py_compile zeromq_webapp/app.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'ibapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b7faadb900832bb1fdfd28da277d39