### PR TITLE
Add TCP JSON consumer for webapp

### DIFF
--- a/zeromq_webapp/requirements.txt
+++ b/zeromq_webapp/requirements.txt
@@ -1,2 +1,1 @@
 flask
-pyzmq


### PR DESCRIPTION
## Summary
- read newline-delimited JSON from TCP port 6565 and update quotes
- drop unused ZeroMQ dependency from the web app

## Testing
- `pip install -r zeromq_webapp/requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68baea3cf95c832b99e44783f48d6511