### PR TITLE
Timestamp TCP quotes and add XAUUSD diff label

### DIFF
--- a/zeromq_webapp/app.py
+++ b/zeromq_webapp/app.py
@@ -2,6 +2,7 @@ import json
 import socketserver
 import threading
 import time
+from datetime import datetime
 from typing import Any, Dict
 
 from flask import Flask, jsonify, render_template
@@ -72,6 +73,8 @@ class QuoteTCPHandler(socketserver.StreamRequestHandler):
                 message = json.loads(line.decode("utf-8"))
             except json.JSONDecodeError:
                 continue
+            # override time with current timestamp for TCP messages
+            message["time"] = datetime.now().isoformat()
             store_quote(message)
 
 

--- a/zeromq_webapp/templates/index.html
+++ b/zeromq_webapp/templates/index.html
@@ -34,6 +34,17 @@
 
       function selectSymbolPair(rowMap) {
         const symbols = Array.from(selectedSymbols);
+        if (symbols.includes('F_XAUUSD1025') && symbols.includes('F_XAUUSD1225')) {
+          const laterRow = rowMap['F_XAUUSD1225'];
+          const earlierRow = rowMap['F_XAUUSD1025'];
+          if (laterRow && earlierRow) {
+            return {
+              later: { row: laterRow },
+              earlier: { row: earlierRow },
+              label: 'F_XAUUSD1025_1225_DIFF'
+            };
+          }
+        }
         if (symbols.length < 2) return null;
         function parse(sym) {
           const row = rowMap[sym];
@@ -84,7 +95,7 @@
               const diffBid = parseFloat(later.bidprice) - parseFloat(earlier.askprice);
               const diffAsk = parseFloat(later.askprice) - parseFloat(earlier.bidprice);
               const time = later.time || earlier.time;
-              const symbolLabel = `DIFF-${pair.later.suffix}-${pair.earlier.suffix}`;
+              const symbolLabel = pair.label || `DIFF-${pair.later.suffix}-${pair.earlier.suffix}`;
               const diffRow = {
                 local_symbol: symbolLabel,
                 bidprice: diffBid.toFixed(2),


### PR DESCRIPTION
## Summary
- Timestamp TCP feed messages with `datetime.now()`
- Add custom synthetic symbol diff `F_XAUUSD1025_1225_DIFF`

## Testing
- `python -m py_compile zeromq_webapp/app.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'ibapi')*

------
https://chatgpt.com/codex/tasks/task_e_68baf9248f8c832ba6c28363a5bac134